### PR TITLE
ci: Upgrade artifact actions

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -79,6 +79,7 @@ jobs:
       with:
         name: compliance.xml
         path: ncs/nrf/compliance.xml
+        overwrite: true
 
     - name: check-warns
       working-directory: ncs/nrf

--- a/.github/workflows/license-reusable.yml
+++ b/.github/workflows/license-reusable.yml
@@ -110,3 +110,4 @@ jobs:
       with:
         name: licenses.xml
         path: ncs/${{ inputs.path }}/licenses.xml
+        overwrite: true


### PR DESCRIPTION
v3 of actions/upload-artifact and
actions/download-artifact becomes obsolete.

From: https://github.com/orgs/community/discussions/142581